### PR TITLE
feat!: use metros device creation instead of facility

### DIFF
--- a/equinix_metal.yaml
+++ b/equinix_metal.yaml
@@ -6,8 +6,8 @@ strict: false
 keyed_groups:
   - prefix: tag
     key: tags
-  - key: facility
-    prefix: equinix_metal_facility
+  - key: metro
+    prefix: equinix_metal_metro
   - key: state
     prefix: equinix_metal_state
 

--- a/roles/metal/defaults/main.yaml
+++ b/roles/metal/defaults/main.yaml
@@ -1,6 +1,5 @@
 ---
 metal_project_id: "{{ lookup('env', 'METAL_PROJ_ID') }}"
-metal_facility: da11
 metal_metro: da
 
 metal_opsbox_config: "m3.small.x86"

--- a/roles/metal/tasks/metal_get_or_provision_ocp_control_hosts.yaml
+++ b/roles/metal/tasks/metal_get_or_provision_ocp_control_hosts.yaml
@@ -6,7 +6,7 @@
     operating_system: custom_ipxe
     ipxe_script_url: "http://{{ hostvars['localhost']['ocp_ips_reservation_network_cidr'] | ansible.utils.nthhost(2) }}/ipxes/trafficstop.ipxe"
     plan: "{{ metal_ocp_control_host_config }}"
-    facility: "{{ metal_facility }}"
+    metro: "{{ metal_metro }}"
     state: present
     wait_for_public_IPv: 4
     always_pxe: true

--- a/roles/metal/tasks/metal_get_or_provision_ocp_worker_hosts.yaml
+++ b/roles/metal/tasks/metal_get_or_provision_ocp_worker_hosts.yaml
@@ -7,7 +7,7 @@
     operating_system: custom_ipxe
     ipxe_script_url: "http://{{ hostvars['localhost']['ocp_ips_reservation_network_cidr'] | ansible.utils.nthhost(2) }}/ipxes/trafficstop.ipxe"
     plan: "{{ metal_ocp_worker_host_config }}"
-    facility: "{{ metal_facility }}"
+    metro: "{{ metal_metro }}"
     state: present
     wait_for_public_IPv: 4
     always_pxe: true

--- a/roles/metal/tasks/metal_get_or_provision_opsbox.yaml
+++ b/roles/metal/tasks/metal_get_or_provision_opsbox.yaml
@@ -5,7 +5,7 @@
     tags: ocp,ocp_rocky8,ocp_opsbox
     operating_system: rocky_8
     plan: "{{ metal_opsbox_config }}"
-    facility: "{{ metal_facility }}"
+    metro: "{{ metal_metro }}"
     state: present
     wait_for_public_IPv: 4
   register: metal_provision_opsbox_output

--- a/roles/metal/tasks/metal_provision_opsbox.yaml
+++ b/roles/metal/tasks/metal_provision_opsbox.yaml
@@ -6,7 +6,7 @@
     tags: ocp,ocp_rocky8,ocp_opsbox
     operating_system: rocky_8
     plan: "{{ metal_opsbox_config }}"
-    facility: "{{ metal_facility }}"
+    metro: "{{ metal_metro }}"
     state: present
     wait_for_public_IPv: 4
   register: metal_provision_opsbox_output

--- a/roles/metal/tasks/metal_reboot_ocp_hosts.yaml
+++ b/roles/metal/tasks/metal_reboot_ocp_hosts.yaml
@@ -6,7 +6,7 @@
     tags: ocp,ocp_rhcos,ocp_control,ocp_networking
     operating_system: custom_ipxe
     plan: "{{ metal_ocp_control_host_config }}"
-    facility: "{{ metal_facility }}"
+    metro: "{{ metal_metro }}"
     state: rebooted
     count: "{{ metal_ocp_num_control_hosts }}"
   register: metal_reboot_ocp_hosts_output
@@ -18,7 +18,7 @@
     tags: ocp,ocp_rhcos,ocp_networking,ocp_worker
     operating_system: custom_ipxe
     plan: "{{ metal_ocp_worker_host_config }}"
-    facility: "{{ metal_facility }}"
+    metro: "{{ metal_metro }}"
     state: rebooted
     count: "{{ metal_ocp_num_worker_hosts }}"
 


### PR DESCRIPTION
Facilities have been deprecated and are no longer available. Deploy using metros.

(This is a naive facility->metro PR. Other considerations are whether this playbook is using the latest Equinix collection and device features of that playbook)

While creating this, I noticed that the environment variable for `METAL_PROJ_ID` could be `METAL_PROJECT_ID` to take advantage of `eval $(metal env --export)`. There may be other opportunities like this.